### PR TITLE
rbc-031 Add DoorInstalled class object

### DIFF
--- a/rbc/room/room.py
+++ b/rbc/room/room.py
@@ -2,6 +2,7 @@ import random
 
 from ..point import Point
 from ..space import Space
+from ..wall.door import Door, DoorInstalled
 from .utils import random_rectangle
 
 
@@ -26,15 +27,9 @@ class Room(Space):
     """
     def __init__(self, room_type=None, **kwargs):
         self.room_type = room_type
+        self.door = None
 
         super().__init__(**kwargs)
-
-    # TODO: Add a method to create doors
-    # prerequisite: Door class object
-    # def create_door(self, corner, offset=1):
-    #     """
-    #     """
-    #     pass
 
     @classmethod
     def random(cls, room_type="random", bounds=None, min_area=MIN_AREA,
@@ -66,3 +61,25 @@ class Room(Space):
             pts = pts_in_bounds
 
         return cls(points=pts, room_type=room_type)
+
+    def add_door(self, door=None, corner=None, offset=0.5):
+        """Add a door to the room"""
+        if not corner:
+            # choose bottom-left corner
+            corner = self.points[0]
+            hinge_coords = (corner.x + offset, corner.y)
+            hinge_point = Point(*hinge_coords)
+            wall_direction = 'X'
+
+            # TODO: implement random door location
+            # choose a random corner
+            # rand_idx = random.randint(0, 3)
+            # corner = self.points[rand_idx]
+            # rand_direction =
+            # hinge_point =
+
+        if not door:
+            door = Door()  # get default Door
+
+        self.door = DoorInstalled(hinge_point=hinge_point, wall_direction=wall_direction,
+                                  door=door)

--- a/rbc/room/test_room.py
+++ b/rbc/room/test_room.py
@@ -5,15 +5,28 @@ from .room import Room
 from ..point import Point
 
 
-def test_10_by_10_room():
-    pt1 = Point(0, 0)
-    pt2 = Point(0, 10)
-    pt3 = Point(10, 10)
-    pt4 = Point(10, 0)
+# =================
+# FIXTURES
+# =================
 
-    square_room = Room(points=[pt1, pt2, pt3, pt4], room_type="shed")
+@pytest.fixture
+def ten_by_ten_points():
+    p1 = Point(0, 0, 0)
+    p2 = Point(0, 120, 0)
+    p3 = Point(120, 120, 0)
+    p4 = Point(120, 0, 0)
 
-    assert square_room.area == 100
+    yield [p1, p2, p3, p4]
+
+
+# =================
+# TESTS
+# =================
+
+def test_10_by_10_room(ten_by_ten_points):
+    square_room = Room(points=ten_by_ten_points, room_type="shed")
+
+    assert square_room.area == 14400
     assert square_room.room_type == "shed"
 
 
@@ -31,3 +44,10 @@ def test_random_room_with_bounds():
     assert rr_bounds[2] <= bounds[2]
     assert rr_bounds[3] <= bounds[3]
     assert random_room.area <= 64
+
+
+def test_room_with_door(ten_by_ten_points):
+    square_room = Room(points=ten_by_ten_points, room_type="shed")
+    square_room.add_door(offset=60)
+
+    assert square_room.door.latch_point.x == 92

--- a/rbc/space/space.py
+++ b/rbc/space/space.py
@@ -33,6 +33,7 @@ class Space(Polygon):
     def __init__(self, points=None, name=None, contents=None, exist_sp=None):
         self.max_retries = 15
         self.name = name
+        self.points = points
 
         super().__init__(shell=[(pt.x, pt.y) for pt in points])
 

--- a/rbc/wall/door/__init__.py
+++ b/rbc/wall/door/__init__.py
@@ -1,4 +1,4 @@
-from .door import Door
+from .door import Door, DoorInstalled
 
 
-__all__ = ['Door']
+__all__ = ['Door', 'DoorInstalled']

--- a/rbc/wall/door/door.py
+++ b/rbc/wall/door/door.py
@@ -1,13 +1,22 @@
 from ...opening import Opening
-
-# NOTE: Factory design pattern?
+from .mixins import SnapToWallMixin
 
 
 class Door(Opening):
-    """Abstract class for doors"""
-    def __init__(self, width=32, height=80, thickness=1.375, jamb_width=4.5625,
-                 unit_price=0):
+    """Base class for doors
 
+    Parameters
+    ----------
+    thickness : float
+        Thickness of the door (unit: inches)
+    jamb_width : float
+        Width of the framing in the wall that encases the door (unit: inches)
+    unit_price : float
+        Cost per door
+
+    """
+    def __init__(self, thickness=1.375, jamb_width=4.5625, unit_price=0,
+                 width=32, height=80, **kwargs):  # Opening params
         self.thickness = thickness
         self.jamb_width = jamb_width
         self.unit_price = unit_price
@@ -16,10 +25,59 @@ class Door(Opening):
 
     def plot(self):
         """
+        TODO:
         - [ ] Plot plan view
         - [ ] Plot elevation view
         """
         pass  # pragma: no cover
 
 
+class DoorInstalled(SnapToWallMixin, Door):
+    """Class for doors that are added to a room or wall
 
+    Parameters
+    ----------
+    hinge_point : Point
+        Plan location (x, y) of the door hinge
+    wall_direction : str
+        direction from hinge to latch (one of [X, -X, Y, -Y])
+    door : Door
+        existing Door object
+
+    """
+    def __init__(self, hinge_point, wall_direction, door=None, **kwargs):
+        self.hinge_point = hinge_point
+        self.wall_start_point = hinge_point  # mixin assignment
+        self.wall_direction = wall_direction
+
+        if door:  # create instance with existing door params
+            door_vars = vars(door)
+            door_params = {
+                # Opening params
+                'width': door_vars.get('width'),
+                'height': door_vars.get('height'),
+                # Door params
+                'thickness': door_vars.get('thickness'),
+                'jamb_width': door_vars.get('jamb_width'),
+                'unit_price': door_vars.get('unit_price'),
+            }
+        else:
+            door_params = kwargs
+
+        stw_params = {  # mixin params
+            'wall_start_point': self.wall_start_point,
+            'wall_direction': self.wall_direction
+        }
+
+        super().__init__(**door_params, **stw_params)
+
+    @property
+    def latch_point(self):
+        """Same as wall_end_point property, opposite of hinge_point"""
+        return self.wall_end_point
+
+    @property
+    def closed_xy(self):
+        """Plan representation of door when closed"""
+
+        return self.xy

--- a/rbc/wall/door/mixins.py
+++ b/rbc/wall/door/mixins.py
@@ -1,0 +1,41 @@
+from shapely.geometry import LineString
+
+from ...point import Point
+
+
+class SnapToWallMixin:
+    """Mixin for objects attached to Wall"""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.wall_start_point = kwargs.get('wall_start_point')
+        self.wall_direction = kwargs.get('wall_direction')
+
+    @property
+    def start_coord(self):
+        return (self.wall_start_point.x, self.wall_start_point.y)
+
+    @property
+    def end_coord(self):
+        if self.wall_direction == 'X':
+            wall_end_coord = (
+                self.start_coord[0] + self.width, self.start_coord[1])
+        elif self.wall_direction == '-X':
+            wall_end_coord = (
+                self.start_coord[0] - self.width, self.start_coord[1])
+        elif self.wall_direction == 'Y':
+            wall_end_coord = (
+                self.start_coord[0], self.start_coord[1] + self.width)
+        elif self.wall_direction == '-Y':
+            wall_end_coord = (
+                self.start_coord[0], self.start_coord[1] - self.width)
+
+        return wall_end_coord
+
+
+    @property
+    def wall_end_point(self):
+        return Point(*self.end_coord)
+
+    @property
+    def xy(self):
+        return LineString([self.start_coord, self.end_coord])

--- a/rbc/wall/door/test_door.py
+++ b/rbc/wall/door/test_door.py
@@ -1,4 +1,6 @@
-from .door import Door
+import pytest
+from .door import Door, DoorInstalled
+from ...point import Point
 
 
 def test_door():
@@ -7,3 +9,30 @@ def test_door():
 
     assert d.thickness == 1.375
     assert d.width == 32
+
+
+@pytest.mark.parametrize("wall_direction, expected_end_coords", [
+    ('X', [(72.0, 40.0)]),
+    ('-X', [(8.0, 40.0)]),
+    ('Y', [(40.0, 72.0)]),
+    ('-Y', [(40.0, 8.0)]),
+])
+def test_door_installed(wall_direction, expected_end_coords):
+    """End coordinates is calculated based on the wall direction"""
+    p = Point(40, 40, 0)
+    d = DoorInstalled(hinge_point=p, wall_direction=wall_direction)
+
+    assert d.closed_xy.length == 32.0
+    assert list(d.latch_point.coords) == expected_end_coords
+
+
+def test_install_existing_door():
+    """DoorInstalled should accept an existing door as a parameter"""
+    p = Point(40, 40, 0)
+    existing_door = Door(width=40, height=84)
+
+    installed_door = DoorInstalled(hinge_point=p, wall_direction='X',
+                                   door=existing_door)
+
+    assert installed_door.width == 40
+    assert installed_door.height == 84


### PR DESCRIPTION
`DoorInstalled` is a subclass of `Door` and also includes the `SnapToWallMixin`. The main difference is that `DoorInstalled` has additional properties that define where a door is installed whereas a `Door` object is only aware of its own properties. A `DoorInstalled` has `hinge_point` and `latch_point` properties defining where the hinge and latch are located, respectively.

```python
>>> d = Door()  # a door that is 32 inches wide and 84 inches high

>>> r = Room(points = [
    Point(0, 0, 0),
    Point(0, 120, 0),
    Point(144, 120, 0),
    Point(144, 0, 0)
])

>>> r.add_door(door=d, offset=6)

>>> list(r.door.hinge_point.coords)
[(6.0, 0.0)]

>>> list(r.door.latch_point.coords)
[(38.0, 0.0)]
```