### PR TITLE
Add capability for loads to be added to horizontal members

### DIFF
--- a/rbc/space/space.py
+++ b/rbc/space/space.py
@@ -232,7 +232,7 @@ class Space(Polygon):
         if first_axis is 'x':
             rand_x = random.choice([x_min, x_max])
             rand_y = random.randint(ceil(y_min), floor(y_max))
-        else:
+        else:  # pragma: no cover
             rand_y = random.choice([y_min, y_max])
             rand_x = random.randint(ceil(x_min), floor(x_max))
 

--- a/rbc/structural/axial_member/test_axial_member.py
+++ b/rbc/structural/axial_member/test_axial_member.py
@@ -48,8 +48,8 @@ def test_axial_member_with_points_without_z():
 
 
 def test_axial_member_with_loads(one_z_points):
-    _l1 = Load(-1)
-    _l2 = Load(2)
+    _l1 = Load(magnitude=-1, direction='Z')
+    _l2 = Load(magnitude=2, direction='Z')
     l1 = {'load': _l1, 'location': 100}
     l2 = {'load': _l2, 'location': 100}
 

--- a/rbc/structural/column/test_column.py
+++ b/rbc/structural/column/test_column.py
@@ -1,10 +1,9 @@
-import pytest
 from unittest import mock
+import pytest
 
-from .column import Column
 from ...point import Point
 from ..load import Load
-
+from .column import Column
 
 # =================
 # FIXTURES
@@ -37,16 +36,16 @@ def test_generic_column(one_z_column):
 def test_load_column(one_z_column):
     c = one_z_column
 
-    kg = Load(1)
+    kg = Load(magnitude=-1, direction='Z')
     c.apply_load(kg)
 
     assert c.load_data == [{'load': kg, 'location': 100}]
-    assert c.base_reaction == -1
+    assert c.base_reaction == 1
 
 
 def test_column_with_loads(one_z_points):
-    l1 = {'load': Load(-1), 'location': 50}
-    l2 = {'load': Load(2), 'location': 100}
+    l1 = {'load': Load(magnitude=-1, direction='Z'),  'location': 50}
+    l2 = {'load': Load(magnitude=2, direction='Z'),  'location': 100}
 
     c = Column(points=one_z_points, loads=[l1, l2])
 
@@ -62,7 +61,7 @@ def test_plot(one_z_column):
     """plt.show() should be called"""
     c = one_z_column
 
-    l1 = Load(-1)
+    l1 = Load(magnitude=-1, direction='Z')
     c.apply_load(l1)
 
     with mock.patch('matplotlib.pyplot.show') as mock_show:

--- a/rbc/structural/horizontal_member/joist.py
+++ b/rbc/structural/horizontal_member/joist.py
@@ -1,9 +1,20 @@
+import logging
+from collections import defaultdict
+
+from ..load import UniformLoad
+from ..load.load_manager import LoadManager
+
 from .horizontal_member import HorizontalMember
 from .mixins import UniformlyLoadedMixin
 
+log = logging.getLogger(__name__)
+
+VALID_CONN_TYPES = ['fixed', 'pinned', 'roller', 'free']
+
 
 class Joist(UniformlyLoadedMixin, HorizontalMember):
-    """Uniformly loaded horizontal member
+    """Uniformly loaded horizontal member that will only support loads in the
+    Z-direction
 
     Parameters
     ----------
@@ -12,11 +23,53 @@ class Joist(UniformlyLoadedMixin, HorizontalMember):
 
     Limitations
     -----------
-    Joist is assumed to be supported by a pin and roller for simpler analysis
+    Joist is assumed to be supported by a pin and roller
 
     """
-
-    def __init__(self, uniform_load=0, **kwargs):
+    def __init__(self, conn=('pinned', 'roller'), **kwargs):
         super().__init__(**kwargs)
 
-        self.uniform_load = uniform_load
+        self.loads = defaultdict(list)
+        self.lm = LoadManager()
+
+        self.conn = conn
+        self.start_conn_type = conn[0]
+        self.end_conn_type = conn[1]
+
+        self.validate()
+
+    def validate(self):
+        if (self.start_conn_type not in VALID_CONN_TYPES or
+            self.end_conn_type not in VALID_CONN_TYPES):
+            raise Exception(
+                f'Invalid connection type: {self.start_conn_type} and '
+                f'{self.end_conn_type}. Connections must be one of '
+                f'{VALID_CONN_TYPES}')
+
+    @property
+    def uniform_load(self):
+        """Filter loads for uniform loads and return sum"""
+        total_uniform_load, unit = self.lm.get_total_uniform_load(self.loads)
+        log.info('%s %s', total_uniform_load, unit)
+        return total_uniform_load
+
+    @property
+    def point_loads(self):
+        """Filter loads and return list of point loads"""
+        return self.lm.get_point_load_list(self.loads)
+
+    def add_load(self, load, loc=None):
+        """
+        Input can be PointLoad, UniformLoad, or MomentLoad
+        """
+        parsed_load, load_type = self.lm.parse_load(load, self.length, loc)
+        self.loads[load_type].append(parsed_load)
+
+    def create_and_add_uniform_load(self, magnitude):
+        """"""
+        new_load = UniformLoad(magnitude=magnitude, direction='Z')
+        self.add_load(new_load)
+
+    def internal_forces_up_to(self, d):  # pragma: no cover
+        """Return internal forces up to a given distance from start"""
+        pass

--- a/rbc/structural/horizontal_member/mixins.py
+++ b/rbc/structural/horizontal_member/mixins.py
@@ -9,10 +9,15 @@ class UniformlyLoadedMixin:
         M = w * l^2 / 8
 
         """
-        w = self.uniform_load
+        w = abs(self.uniform_load)
         l = self.length
 
-        return w * l ** 2 / 8
+        if 'pinned' in self.conn and 'roller' in self.conn:
+            return w * l ** 2 / 8
+        else:
+            raise Exception('max_moment method only supports simple beams. '
+                            'Connections must be combination for pinned and '
+                            'roller.')
 
     @property
     def max_shear(self):
@@ -24,7 +29,12 @@ class UniformlyLoadedMixin:
         V = w * l / 2
 
         """
-        w = self.uniform_load
+        w = abs(self.uniform_load)
         l = self.length
 
-        return w * l / 2
+        if 'pinned' in self.conn and 'roller' in self.conn:
+            return w * l / 2
+        else:
+            raise Exception('max_shear method only supports simple beams. '
+                            'Connections must be combination for pinned and '
+                            'roller.')

--- a/rbc/structural/horizontal_member/tests/test_joist.py
+++ b/rbc/structural/horizontal_member/tests/test_joist.py
@@ -2,10 +2,81 @@ import pytest
 
 from rbc.point import Point
 from ..joist import Joist
+from ...load import PointLoad, UniformLoad
 
 
 def test_joist():
-    b = Joist(length=10, uniform_load=2)
+    j = Joist(length=10)
+    j.create_and_add_uniform_load(-2)
 
-    assert b.max_moment == 25
-    assert b.max_shear == 10
+    assert j.length == 10
+    assert j.uniform_load == -2
+    assert j.max_moment == 25
+    assert j.max_shear == 10
+
+    # Joist should be accept UniformLoads
+    l = UniformLoad(magnitude=-2, direction='Z')
+    j.add_load(l)
+
+    assert j.uniform_load == -4
+    assert j.max_moment == 50
+    assert j.max_shear == 20
+
+
+def test_conn_type():
+    j = Joist(length=10, conn=('roller', 'pinned'))
+
+    assert j.start_conn_type == 'roller'
+    assert j.end_conn_type == 'pinned'
+    assert j.conn == ('roller', 'pinned')
+
+
+def test_invalid_conn_types():
+    with pytest.raises(Exception):
+        Joist(length=10, conn=('pinned', 'glued'))
+
+
+def test_moment_shear_with_invalid_conn():
+    j = Joist(length=10, conn=('pinned', 'pinned'))
+
+    # max_moment and max_shear property methods checks that self.conn includes
+    #  both 'pinned' and 'roller'
+    with pytest.raises(Exception):
+        j.max_moment
+    with pytest.raises(Exception):
+        j.max_shear
+
+
+def test_joist_with_uniform_load_and_loc():
+    j = Joist(length=10, conn=('roller', 'pinned'))
+    l = UniformLoad(magnitude=-2, direction='Z')
+
+    j.add_load(l, loc=(0, 5))
+
+    assert j.uniform_load == -2
+
+
+def test_joist_with_uniform_load_and_invalid_loc():
+    j = Joist(length=10, conn=('roller', 'pinned'))
+    l = UniformLoad(magnitude=-2, direction='Z')
+
+    # loc for uniform loads needs to be a tuple (start, end)
+    with pytest.raises(Exception):
+        j.add_load(l, loc=(5))
+
+
+def test_joist_with_point_loads():
+    j = Joist(length=10)
+    l = PointLoad(magnitude=-5, direction='Z')
+
+    j.add_load(l, loc=5)
+
+    assert j.point_loads == [{'load': l, 'mem_start': 5}]
+
+
+def test_joist_with_invalid_point_load():
+    j = Joist(length=10)
+    l = PointLoad(magnitude=-5, direction='Z')
+
+    with pytest.raises(Exception):
+        j.add_load(l)

--- a/rbc/structural/load/__init__.py
+++ b/rbc/structural/load/__init__.py
@@ -1,4 +1,10 @@
-from .load import Load, PointLoad
+from .load import Load, PointLoad, UniformLoad
+from .load_manager import LoadManager
 
 
-__all__ = ['Load', 'PointLoad']
+__all__ = [
+    'Load',
+    'PointLoad',
+    'UniformLoad',
+    'LoadManager',
+]

--- a/rbc/structural/load/load.py
+++ b/rbc/structural/load/load.py
@@ -1,31 +1,91 @@
 from abc import ABC
 
+from ...point import Point
+
+
+VALID_FORCE_UNITS = ['lb', 'kip']
+VALID_LENGTH_UNITS = ['in', 'ft']
+
 
 class Load(ABC):
+    """Parent class for PointLoads and Uniform Loads
+
+    Parameters
+    ----------
+    magnitude : float
+        Intensity of force quantified by kips or kN
+    direction : str
+        X, Y, or Z
+    label : str
+        For use as keys in dicts
+    description : str
+        Property to provide additional context
+
+    TODO:
+    - [ ] Support for loads that are not in the principal X, Y, and Z axes
+    """
+
     def __init__(self, magnitude, direction=None, label=None,
-                 description=None):
+                 description=None, force_unit='kip'):
+        if direction not in ['X', 'Y', 'Z']:
+            raise Exception('Direction must be either X, Y, or Z')
         self.magnitude = magnitude
         self.direction = direction
         self.label = label
         self.description = description
-
+        self.force_unit = force_unit
+        self.validate()
 
     def __repr__(self):
-        return f"Load({self.magnitude}, '{self.direction}')"
+        return f"Load({self.magnitude} {self.force_unit}, '{self.direction}')"
 
     def __str__(self):
         if self.label:
-            return (f'{self.label}: {self.magnitude} in the {self.direction} '
-                    'direction')
+            return (f'{self.label}: {self.magnitude} {self.force_unit}s in '
+                    f'the {self.direction} direction')
         else:
-            return f'{self.magnitude} in the {self.direction} direction'
+            return (f'{self.magnitude} {self.force_unit}s in the '
+                    f'{self.direction} direction')
 
+    def validate(self):
+        if self.force_unit not in VALID_FORCE_UNITS:
+            raise Exception(f'force_unit must be one of {VALID_FORCE_UNITS}')
 
 
 class PointLoad(Load):
-    def __init__(self, distance=None, **kwargs):
+    """A force applied at a single point in one direction
+
+    Parameters
+    ----------
+    distance : float
+        offset distance from member's start_point
+
+    """
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
 
-        # NOTE not likely to keep this attribute as the host should be
-        # responsible for knowing where the load is applied.
-        self.distance = distance
+
+class UniformLoad(Load):
+    """A load that is distributed evenly along a line
+
+    By default, UniformLoads should be assumed to be applied to the entire
+    length of a member.
+
+    Parameters
+    ----------
+    magnitude : float
+        Intensity of uniform load
+    length : float
+        Length of member where uniform load is applied
+
+    """
+    def __init__(self, magnitude, direction, length_unit='ft', **kwargs):
+        self.length_unit = length_unit
+        super().__init__(magnitude, direction, **kwargs)
+
+        self.validate()
+
+    def validate(self):
+        super().validate()
+        if self.length_unit not in VALID_LENGTH_UNITS:
+            raise Exception(f'length_unit must be one of {VALID_LENGTH_UNITS}')

--- a/rbc/structural/load/load_manager.py
+++ b/rbc/structural/load/load_manager.py
@@ -1,0 +1,58 @@
+import logging
+
+from .load import PointLoad, UniformLoad
+from .utils import sum_loads
+
+log = logging.getLogger(__name__)
+
+
+class LoadManager:
+    def parse_load(self, load, mem_length, loc=None):
+        """Return dict with Load object and load type"""
+
+        if type(load) == PointLoad:
+            if not loc:
+                raise Exception('PointLoads need the loc parameter.')
+
+            load_type = 'point'
+            load_dict = {
+                'load': load,
+                'mem_start': loc,
+            }
+        elif type(load) == UniformLoad:
+            if not loc:
+                mem_start = 0
+                mem_end = mem_length
+            else:
+                try:
+                    mem_start = loc[0]
+                    mem_end = loc[1]
+                except:
+                    raise Exception('Error occurred while parsing loc')
+
+            load_type = 'uniform'
+            load_dict = {
+                'load': load,
+                'mem_start': mem_start,
+                'mem_end': mem_end,
+            }
+
+        return load_dict, load_type
+
+    def get_total_uniform_load(self, load_dict):
+        """Filter loads for uniform loads and return sum"""
+        uniform_loads = []
+
+        for load_data in load_dict['uniform']:
+            uniform_loads.append(load_data['load'])
+
+        if uniform_loads:
+            sum, unit = sum_loads(*uniform_loads)
+            return sum, unit
+
+        else:
+            return 0, None
+
+    def get_point_load_list(self, load_dict):
+
+        return load_dict['point']

--- a/rbc/structural/load/test_load.py
+++ b/rbc/structural/load/test_load.py
@@ -1,4 +1,6 @@
-from .load import Load, PointLoad
+import pytest
+
+from .load import Load, PointLoad, UniformLoad
 
 
 def test_generic_load():
@@ -8,17 +10,40 @@ def test_generic_load():
     assert l.direction == 'Y'
     assert l.label == 'car'
     assert l.description == 'weight of car'
-    assert l.__repr__() == "Load(5, 'Y')"
-    assert l.__str__() == 'car: 5 in the Y direction'
+    assert l.__repr__() == "Load(5 kip, 'Y')"
+    assert l.__str__() == 'car: 5 kips in the Y direction'
 
 
 def test_load_without_label():
     l = Load(magnitude=5, direction='Y', description='weight of car')
 
-    assert l.__str__() == '5 in the Y direction'
+    assert l.__str__() == '5 kips in the Y direction'
+
+
+def test_load_without_direction():
+    with pytest.raises(Exception):
+        l = Load(magnitude=5)
 
 
 def test_point_load():
     p = PointLoad(magnitude=5, direction='Y', description='weight of sofa')
 
     assert p.magnitude == 5
+
+
+def test_uniform_load():
+    u = UniformLoad(magnitude=-2, force_unit='kip', length_unit='ft',
+                    direction='Z')
+
+    assert type(u) == UniformLoad
+
+
+def test_load_with_invalid_force_unit():
+    with pytest.raises(Exception):
+        l = Load(magnitude=-5, force_unit='oz', direction='Z')
+
+
+def test_load_with_invalid_length_unit():
+    with pytest.raises(Exception):
+        l = UniformLoad(magnitude=-2, force_unit='lb', length_unit='mi',
+                        direction='Z')

--- a/rbc/structural/load/test_utils.py
+++ b/rbc/structural/load/test_utils.py
@@ -1,0 +1,54 @@
+import pytest
+
+from .load import PointLoad, UniformLoad
+from .utils import sum_loads
+
+
+# =================
+# FIXTURES
+# =================
+
+@pytest.fixture
+def two_kip_per_ft_uniform_load():
+    u = UniformLoad(magnitude=-2, direction='Z', force_unit='kip')
+    yield u
+
+@pytest.fixture
+def three_kip_per_ft_uniform_load():
+    u = UniformLoad(magnitude=-3, direction='Z', force_unit='kip')
+    yield u
+
+@pytest.fixture
+def five_kip_point_load():
+    p = PointLoad(magnitude=-5, direction='Z', force_unit='kip')
+    yield p
+
+
+# =================
+# TESTS
+# =================
+
+def test_loads_must_be_same_type(two_kip_per_ft_uniform_load,
+                                 three_kip_per_ft_uniform_load,
+                                 five_kip_point_load):
+    s = sum_loads(two_kip_per_ft_uniform_load, three_kip_per_ft_uniform_load)
+    assert s == (-5, 'kip')
+
+    with pytest.raises(Exception):
+        sum_loads(two_kip_per_ft_uniform_load, five_kip_point_load)
+
+
+def test_loads_must_be_in_same_direction(two_kip_per_ft_uniform_load,
+                                         three_kip_per_ft_uniform_load):
+    three_kip_per_ft_uniform_load.direction = 'X'
+
+    with pytest.raises(Exception):
+        sum_loads(two_kip_per_ft_uniform_load, three_kip_per_ft_uniform_load)
+
+
+def test_loads_must_have_the_same_units(two_kip_per_ft_uniform_load,
+                                        three_kip_per_ft_uniform_load):
+    three_kip_per_ft_uniform_load.force_unit = 'lb'
+
+    with pytest.raises(Exception):
+        sum_loads(two_kip_per_ft_uniform_load, three_kip_per_ft_uniform_load)

--- a/rbc/structural/load/utils.py
+++ b/rbc/structural/load/utils.py
@@ -1,0 +1,31 @@
+import logging
+
+log = logging.getLogger(__name__)
+
+def sum_loads(*loads):
+    """
+
+    Requirements
+    ------------
+
+    - all loads need to be the same type (PointLoad, UniformLoad, MomentLoad)
+    - all loads need to be acting in the same direction (X, Y, Z)
+
+    """
+    log.info('Received loads: %s', loads)
+
+    load_type = type(loads[0])
+    direction = loads[0].direction
+    unit = loads[0].force_unit
+
+    for load in loads:
+        if type(load) != load_type:
+            raise Exception('Given loads must have the same type.')
+
+        if load.direction != direction:
+            raise Exception('Given loads must have the same direction.')
+
+        if load.force_unit != unit:
+            raise Exception('Given loads must have the same direction.')
+
+    return sum([load.magnitude for load in loads]), unit

--- a/rbc/structural/section/test_section.py
+++ b/rbc/structural/section/test_section.py
@@ -3,6 +3,7 @@ import pytest
 from .section import Section
 from ...point import Point
 
+
 # =================
 # FIXTURES
 # =================
@@ -52,6 +53,7 @@ def test_section_with_invalid_params():
     # radius needs to be a float or int
     with pytest.raises(Exception):
         Section(radius='r')
+
 
 def test_circle_section():
     s = Section(radius=2)


### PR DESCRIPTION
Issue: #43 

### Changes

* New class object, `LoadManager` was added
  * The `LoadManager` knows how to store loads and how to retrieve loads from dicts.
* Loads are now defined with `magnitude` and `direction` parameters


### Example Code

```python
>>> j = Joist(length=10)

# UniformLoads can be added with the `create_and_add_uniform_load` method
>>> j.create_and_add_uniform_load(-2)

# UniformLoads can be added with the `add_load` method
>>> l = UniformLoad(magnitude=-2, direction='Z')
>>> j.add_load(l)

>>> j.uniform_load 
-4

>>> j.max_moment
50

>>> j.max_shear
20
```